### PR TITLE
Fix: Address three small bugs in UI and data processing

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -37,6 +37,7 @@
     "invited": "Invited",
     "noPapers": "No papers found for this year.",
     "noPresentations": "No presentations found for this year.",
+    "noMisc": "No other publications found for this year.",
     "showAll": "Show All"
   },
   "awards": {

--- a/public/locales/ja/translations.json
+++ b/public/locales/ja/translations.json
@@ -37,6 +37,7 @@
     "invited": "招待講演",
     "noPapers": "該当年の論文はありません。",
     "noPresentations": "該当年の発表はありません。",
+    "noMisc": "該当年のその他の出版物はありません。",
     "showAll": "すべて表示"
   },
   "awards": {

--- a/scripts/generatePublicApi.cjs
+++ b/scripts/generatePublicApi.cjs
@@ -71,14 +71,18 @@ const formattedPapers = visiblePapers.map(paper => {
   let authors = '';
   if (paper['著者(英語)']) {
     authors = paper['著者(英語)'].replace(/^\[|\]$/g, '');
+    if (authors) authors = authors.replace(/\\$/, '');
   } else if (paper['著者(日本語)']) {
     authors = paper['著者(日本語)'].replace(/^\[|\]$/g, '');
+    if (authors) authors = authors.replace(/\\$/, '');
   }
   let authorsJa = '';
   if (paper['著者(日本語)']) {
     authorsJa = paper['著者(日本語)'].replace(/^\[|\]$/g, '');
+    if (authorsJa) authorsJa = authorsJa.replace(/\\$/, '');
   } else if (paper['著者(英語)']) {
     authorsJa = paper['著者(英語)'].replace(/^\[|\]$/g, '');
+    if (authorsJa) authorsJa = authorsJa.replace(/\\$/, '');
   }
 
   return {
@@ -106,15 +110,19 @@ const formattedPresentations = visiblePresentations.map(presentation => {
   let speakers = '';
   if (presentation['講演者(英語)']) {
     speakers = presentation['講演者(英語)'].replace(/^\[|\]$/g, '');
+    if (speakers) speakers = speakers.replace(/\\$/, '');
   } else if (presentation['講演者(日本語)']) {
     speakers = presentation['講演者(日本語)'].replace(/^\[|\]$/g, '');
+    if (speakers) speakers = speakers.replace(/\\$/, '');
   }
 
   let speakersJa = '';
   if (presentation['講演者(日本語)']) {
     speakersJa = presentation['講演者(日本語)'].replace(/^\[|\]$/g, '');
+    if (speakersJa) speakersJa = speakersJa.replace(/\\$/, '');
   } else if (presentation['講演者(英語)']) {
     speakersJa = presentation['講演者(英語)'].replace(/^\[|\]$/g, '');
+    if (speakersJa) speakersJa = speakersJa.replace(/\\$/, '');
   }
 
   let year = '';
@@ -166,15 +174,19 @@ const formattedMisc = visibleMisc.map(misc => {
   let authors = '';
   if (misc['著者(英語)']) {
     authors = misc['著者(英語)'].replace(/^\[|\]$/g, '');
+    if (authors) authors = authors.replace(/\\$/, '');
   } else if (misc['著者(日本語)']) {
     authors = misc['著者(日本語)'].replace(/^\[|\]$/g, '');
+    if (authors) authors = authors.replace(/\\$/, '');
   }
 
   let authorsJa = '';
   if (misc['著者(日本語)']) {
     authorsJa = misc['著者(日本語)'].replace(/^\[|\]$/g, '');
+    if (authorsJa) authorsJa = authorsJa.replace(/\\$/, '');
   } else if (misc['著者(英語)']) {
     authorsJa = misc['著者(英語)'].replace(/^\[|\]$/g, '');
+    if (authorsJa) authorsJa = authorsJa.replace(/\\$/, '');
   }
 
   return {

--- a/src/components/Awards.tsx
+++ b/src/components/Awards.tsx
@@ -83,6 +83,10 @@ const Awards: React.FC = () => {
   const hasAnyData =
     awards.length > 0 || grants.length > 0 || projects.length > 0;
 
+  if (!isLoading && !hasAnyData) {
+    return null;
+  }
+
   return (
     <section id="awards" className="py-16 bg-background-light">
       <div className="container mx-auto px-4">


### PR DESCRIPTION
This commit resolves the following three issues:

1.  **Trailing backslashes in names:** Modifies `scripts/generatePublicApi.cjs` to remove any trailing backslashes from author and speaker names originating from ResearchMap data. This ensures cleaner display in the UI.

2.  **Missing `publications.noMisc` translation:** Adds the `noMisc` key to both English (`public/locales/en/translations.json`) and Japanese (`public/locales/ja/translations.json`) translation files. This allows the Publications component to display a proper message when no miscellaneous items are found.

3.  **Awards section visibility:** Updates `src/components/Awards.tsx` so that the entire "Awards & Projects" section (including its title) is not rendered if there are no awards, grants, or projects to display. Previously, the section title and a "no data" message would appear.